### PR TITLE
postprocessing example

### DIFF
--- a/examples/postprocessing.rs
+++ b/examples/postprocessing.rs
@@ -1,0 +1,267 @@
+#![recursion_limit = "512"]
+#![feature(integer_atomics)]
+
+/* common */
+extern crate futures;
+extern crate nalgebra as na;
+extern crate uni_app;
+extern crate unigame;
+
+mod appfs;
+
+use appfs::*;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::ops::{Deref, DerefMut};
+use na::{Point3, UnitQuaternion, Vector3};
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+
+use unigame::engine::*;
+use uni_app::{App, AppConfig, AppEvent, FPS};
+
+type Handle<T> = Rc<RefCell<T>>;
+
+struct Game {
+    list: Vec<Handle<GameObject>>,
+    engine: AppEngine,
+    point_light_coms: Vec<Weak<Component>>,
+    rt: Rc<RenderTexture>,
+}
+
+impl Game {
+    fn new(engine: AppEngine) -> Game {
+        let mut g = Game {
+            list: Vec::new(),
+            engine: engine,
+            point_light_coms: Vec::new(),
+            rt: Rc::new(RenderTexture::new(1024, 1024)),
+        };
+
+        g.setup();
+        g
+    }
+
+    pub fn step(&mut self) {
+        self[5].borrow_mut().transform
+                .append_rotation_mut(&UnitQuaternion::new(Vector3::new(0.01, 0.02, 0.005)));
+    }
+
+    pub fn reset(&mut self) {
+        self.list.clear();
+        self.engine.asset_system_mut().reset();
+        self.point_light_coms.clear();
+
+        self.setup();
+    }
+
+    pub fn setup(&mut self) {
+        // add direction light to scene.
+        let _dir_light_com = {
+            let go = self.engine.new_gameobject();
+            // Make sure it is store some where, else it will gc
+            self.push(go.clone());
+
+            let mut go_mut = go.borrow_mut();
+            let com = go_mut.add_component(Light::new(Directional {
+                direction: Vector3::new(0.5, -1.0, 1.0).normalize(),
+                ambient: Vector3::new(0.2, 0.2, 0.2),
+                diffuse: Vector3::new(0.5, 0.5, 0.5),
+                specular: Vector3::new(1.0, 1.0, 1.0),
+            }));
+
+            com
+        };
+
+        // Add 4 points light to scene
+        let point_light_positions = vec![
+            Vector3::new(-30.0, 30.0, -30.0),
+            Vector3::new(-15.0, 300.0, -10.0),
+            Vector3::new(30.0, 50.0, 30.0),
+            Vector3::new(30.0, 100.0, -20.0),
+        ];
+
+        for p in point_light_positions.into_iter() {
+            let go = self.engine.new_gameobject();
+            // Make sure it is store some where, else it will gc
+            self.push(go.clone());
+
+            let mut go_mut = go.borrow_mut();
+            let com = Light::new(Point {
+                position: p,
+                ambient: Vector3::new(0.05, 0.05, 0.05),
+                diffuse: Vector3::new(0.8, 0.8, 0.8),
+                specular: Vector3::new(1.0, 1.0, 1.0),
+                constant: 1.0,
+                linear: 0.022,
+                quadratic: 0.0019,
+            });
+
+            self.point_light_coms
+                .push(Arc::downgrade(&go_mut.add_component(com)));
+        }
+
+        let go = { self.engine.new_gameobject() };
+        {
+            let db = &mut self.engine.asset_system();
+            let mut go_mut = go.borrow_mut();
+            let mut params = HashMap::new();
+            params.insert(
+                "uMaterial.diffuse".to_string(),
+                MaterialParam::Texture(db.new_texture("tex_a.png")),
+            );
+            params.insert(
+                "uMaterial.shininess".to_string(),
+                MaterialParam::Float(32.0),
+            );
+            go_mut.add_component(Material::new(db.new_program("phong"), params));
+            go_mut.add_component(Mesh::new(db.new_mesh_buffer("cube")));
+        }
+        self.list.push(go.clone());
+
+        let screen_quad = { self.engine.new_gameobject() };
+        {
+            let db = &mut self.engine.asset_system();
+            let mut go_mut = screen_quad.borrow_mut();
+            let mut params = HashMap::new();
+            params.insert(
+                "uDiffuse".to_string(),
+                MaterialParam::Texture(self.rt.as_texture()),
+            );
+            go_mut.add_component(Material::new(db.new_program("crt"), params));
+            go_mut.add_component(Mesh::new(db.new_mesh_buffer("screen_quad")));
+            // go_mut.visible=false;
+        }
+        self.list.push(screen_quad.clone());
+    }
+}
+
+impl Deref for Game {
+    type Target = Vec<Handle<GameObject>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.list
+    }
+}
+
+impl DerefMut for Game {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.list
+    }
+}
+
+pub fn main() {
+    let size = (800, 600);
+    let config = AppConfig::new("Postprocessing demo", size);
+    let app = App::new(config);
+    {
+        let mut game = Game::new(Engine::new(app.canvas(), size));
+        game.engine.main_camera = Some(Rc::new(RefCell::new(Camera::new())));
+
+        use imgui::Metric::*;
+
+        let mut fps = FPS::new();
+        let mut last_event = None;
+        let mut eye = Vector3::new(-3.0, 3.0, -3.0);
+        let up = Vector3::new(0.0, 1.0, 0.0);
+
+        app.run(move |app: &mut App| {
+            game.engine.begin();
+            fps.step();
+            game.step();
+
+            // Handle Events
+            {
+                let target = Vector3::new(0.0, 0.0, 0.0);
+                let front = (eye - target).normalize();
+
+                let events = app.events.borrow();
+                for evt in events.iter() {
+                    last_event = Some(evt.clone());
+                    match evt {
+                        &AppEvent::Click(_) => {}
+
+                        &AppEvent::KeyDown(ref key) => {
+                            match key.code.as_str() {
+                                "KeyA" => eye = na::Rotation3::new(up * -0.02) * eye,
+                                "KeyD" => eye = na::Rotation3::new(up * 0.02) * eye,
+                                "KeyW" => eye = eye - front * 2.0,
+                                "KeyS" => eye = eye + front * 2.0,
+                                "Escape" => game.reset(),
+                                _ => (),
+                            };
+                        }
+
+                        _ => (),
+                    }
+                }
+            }
+
+            // Update Camera
+            {
+                let mut cam = game.engine.main_camera.as_ref().unwrap().borrow_mut();
+                cam.lookat(
+                    &Point3::from_coordinates(eye),
+                    &Point3::new(0.0, 0.0, 0.0),
+                    &Vector3::new(0.0, 1.0, 0.0),
+                );
+            }
+
+            // Update Light
+            for light_com_weak in game.point_light_coms.iter() {
+                if let Some(light_com) = light_com_weak.upgrade() {
+                    if let Some(lr) = light_com.try_as::<Light>() {
+                        let mut light = lr.borrow_mut();
+                        let mut pos = light.point().unwrap().position;
+
+                        light.point_mut().unwrap().position = na::Rotation3::new(up * 0.02) * pos;
+                    }
+                }
+            }
+
+            // Setup fb for camera
+            {
+                let mut cam = game.engine.main_camera.as_ref().unwrap().borrow_mut();
+                cam.render_texture = Some(game.rt.clone());
+
+                // Setup proper viewport to render to the whole texture
+                cam.rect = Some(((0, 0), (1024, 1024)));
+                // show only cube
+                game.list[5].borrow_mut().visible=true;
+                game.list[6].borrow_mut().visible=false;
+                imgui::pivot((0.0, 0.0));
+                imgui::label(
+                    Native(0.0, 0.0) + Pixel(8.0, 8.0),
+                    &format!("fps: {} nobj: {}", fps.fps, game.engine.objects.len()),
+                );
+
+                imgui::pivot((1.0, 1.0));
+                imgui::label(
+                    Native(1.0, 1.0) - Pixel(8.0, 8.0),
+                    "[Esc]  : reload all (include assets)",
+                );
+
+                imgui::pivot((1.0, 0.0));
+                imgui::label(
+                    Native(1.0, 0.0) + Pixel(-8.0, 8.0),
+                    &format!("last event: {:?}", last_event),
+                );
+                // Render current scene by camera using given frame buffer
+                game.engine.render_pass(&cam);
+
+                // Clean up stuffs in camera, as later we could render normally
+                cam.render_texture = None;
+                cam.rect = None;
+            }
+            // show only screen_quad
+            game.list[5].borrow_mut().visible=false;
+            game.list[6].borrow_mut().visible=true;
+            // Render
+            game.engine.render();
+
+            // End
+            game.engine.end();
+        });
+    }
+}

--- a/examples/postprocessing.rs
+++ b/examples/postprocessing.rs
@@ -131,7 +131,6 @@ impl Game {
             );
             go_mut.add_component(Material::new(db.new_program("crt"), params));
             go_mut.add_component(Mesh::new(db.new_mesh_buffer("screen_quad")));
-            // go_mut.visible=false;
         }
         self.list.push(screen_quad.clone());
     }
@@ -228,8 +227,8 @@ pub fn main() {
                 // Setup proper viewport to render to the whole texture
                 cam.rect = Some(((0, 0), (1024, 1024)));
                 // show only cube
-                game.list[5].borrow_mut().visible=true;
-                game.list[6].borrow_mut().visible=false;
+                game.list[5].borrow_mut().active=true;
+                game.list[6].borrow_mut().active=false;
                 imgui::pivot((0.0, 0.0));
                 imgui::label(
                     Native(0.0, 0.0) + Pixel(8.0, 8.0),
@@ -255,8 +254,8 @@ pub fn main() {
                 cam.rect = None;
             }
             // show only screen_quad
-            game.list[5].borrow_mut().visible=false;
-            game.list[6].borrow_mut().visible=true;
+            game.list[5].borrow_mut().active=false;
+            game.list[6].borrow_mut().active=true;
             // Render
             game.engine.render();
 

--- a/src/engine/asset/quad.rs
+++ b/src/engine/asset/quad.rs
@@ -13,10 +13,10 @@ impl Quad {
 
         let uvs: Vec<f32> = vec![
             // Top face
-            0.0, 0.0,
             0.0, 1.0,
-            1.0, 1.0,
+            0.0, 0.0,
             1.0, 0.0,
+            1.0, 1.0,
         ];
 
         let indices: Vec<u16> = vec![

--- a/src/engine/core/game_object.rs
+++ b/src/engine/core/game_object.rs
@@ -74,7 +74,7 @@ impl Component {
 pub struct GameObject {
     pub transform: Isometry3<f32>,
     pub scale: Vector3<f32>,
-    pub visible: bool,
+    pub active: bool,
     pub components: Vec<Arc<Component>>,
 }
 

--- a/src/engine/core/game_object.rs
+++ b/src/engine/core/game_object.rs
@@ -74,7 +74,7 @@ impl Component {
 pub struct GameObject {
     pub transform: Isometry3<f32>,
     pub scale: Vector3<f32>,
-
+    pub visible: bool,
     pub components: Vec<Arc<Component>>,
 }
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -350,7 +350,7 @@ where
         for obj in objects.iter() {
             obj.upgrade().map(|obj| {
                 let object = obj.borrow();
-                if object.visible {
+                if object.active {
                     let result = object.find_component::<Material>();
 
                     if let Some((material, _)) = result {
@@ -424,7 +424,7 @@ impl<A: AssetSystem> IEngine for Engine<A> {
         let go = Rc::new(RefCell::new(GameObject {
             transform: Isometry3::identity(),
             scale: Vector3::new(1.0, 1.0, 1.0),
-            visible: true,
+            active: true,
             components: vec![],
         }));
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -350,15 +350,17 @@ where
         for obj in objects.iter() {
             obj.upgrade().map(|obj| {
                 let object = obj.borrow();
-                let result = object.find_component::<Material>();
+                if object.visible {
+                    let result = object.find_component::<Material>();
 
-                if let Some((material, _)) = result {
-                    match self.setup_material(&mut ctx, &material) {
-                        Ok(_) => self.render_object(gl, &mut ctx, &object, camera),
-                        Err(ref err) if *err != AssetError::NotReady => {
-                            panic!("Failed to load material {:?}", err);
+                    if let Some((material, _)) = result {
+                        match self.setup_material(&mut ctx, &material) {
+                            Ok(_) => self.render_object(gl, &mut ctx, &object, camera),
+                            Err(ref err) if *err != AssetError::NotReady => {
+                                panic!("Failed to load material {:?}", err);
+                            }
+                            _ => (),
                         }
-                        _ => (),
                     }
                 }
             });
@@ -422,6 +424,7 @@ impl<A: AssetSystem> IEngine for Engine<A> {
         let go = Rc::new(RefCell::new(GameObject {
             transform: Isometry3::identity(),
             scale: Vector3::new(1.0, 1.0, 1.0),
+            visible: true,
             components: vec![],
         }));
 

--- a/static/crt_fs.glsl
+++ b/static/crt_fs.glsl
@@ -1,0 +1,38 @@
+#ifndef GL_ES
+#define varying in
+#define gl_FragColor FragColor
+out vec4 FragColor;
+#endif
+
+varying vec3 vColor;
+varying vec2 vTextureCoord;
+uniform sampler2D uDiffuse;
+
+const float crtBend			= 2.8;
+const float crtOverscan		= 0.1;
+vec2 crt(vec2 coord)
+{
+	// put in symmetrical coords
+	coord = (coord - 0.5) * 2.0 / (crtOverscan + 1.0);
+
+	coord *= 1.1;
+
+	// deform coords
+	coord.x *= 1.0 + pow((abs(coord.y) / crtBend), 2.0);
+	coord.y *= 1.0 + pow((abs(coord.x) / crtBend), 2.0);
+
+	// transform back to 0.0 - 1.0 space
+	coord  = (coord / 2.0) + 0.5;
+
+	return coord;
+}
+
+void main(void) {
+    vec2 crtCoords = crt(vTextureCoord.st);
+    if (crtCoords.x < 0.0 || crtCoords.x > 1.0 || crtCoords.y < 0.0 || crtCoords.y > 1.0) {
+    	gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    } else {
+        float coef=0.8 + abs(sin(600*vTextureCoord.t)) * 0.2;
+        gl_FragColor = texture2D(uDiffuse, crtCoords) * vec4(0.8,1.0*coef,0.7,1.0)  ;
+    }
+}

--- a/static/crt_fs.glsl
+++ b/static/crt_fs.glsl
@@ -32,7 +32,7 @@ void main(void) {
     if (crtCoords.x < 0.0 || crtCoords.x > 1.0 || crtCoords.y < 0.0 || crtCoords.y > 1.0) {
     	gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
     } else {
-        float coef=0.8 + abs(sin(600*vTextureCoord.t)) * 0.2;
+        float coef=0.8 + abs(sin(600.0*vTextureCoord.t)) * 0.2;
         gl_FragColor = texture2D(uDiffuse, crtCoords) * vec4(0.8,1.0*coef,0.7,1.0)  ;
     }
 }

--- a/static/crt_fs.glsl
+++ b/static/crt_fs.glsl
@@ -8,7 +8,7 @@ varying vec3 vColor;
 varying vec2 vTextureCoord;
 uniform sampler2D uDiffuse;
 
-const float crtBend			= 2.8;
+const float crtBend			= 4.8;
 const float crtOverscan		= 0.1;
 vec2 crt(vec2 coord)
 {

--- a/static/crt_vs.glsl
+++ b/static/crt_vs.glsl
@@ -1,0 +1,9 @@
+attribute vec3 aVertexPosition;
+attribute vec2 aTextureCoord;
+varying vec2 vTextureCoord;
+uniform mat4 uMMatrix;
+            
+void main(void) {
+    gl_Position = uMMatrix * vec4(aVertexPosition, 1.0);        
+    vTextureCoord = aTextureCoord;
+}


### PR DESCRIPTION
Ok finally, a working post-processing example.
Run it with :
`cargo run --release --example postprocessing`

To achieve this with current engine, I had to add a `visible` field on Gameobject. I think that's something that will be needed anyway.
With this, I can render only the cube on the framebuffer, then render only a screen_quad on the screen using a custom shader (some basic crt effect).

I had to swap vertically the uvs in the Quad mesh, else it was rendered upside down. Not sure that's the right fix.

While it's kind of a hack, I find it nice to be able to do this with the basic engine game object/camera features instead of using a hardcoded post-processing system. It's the proof the engine is flexible and makes it possible to be creative.
