### PR TITLE
more material param types (vec2,vec3,vec4)

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -182,6 +182,15 @@ where
                 &MaterialParam::Float(f) => {
                     prog.set(&name, f);
                 }
+                &MaterialParam::Vec2(f1,f2) => {
+                    prog.set(&name, Vector2::new(f1,f2));
+                }
+                &MaterialParam::Vec3(f1,f2,f3) => {
+                    prog.set(&name, Vector3::new(f1,f2,f3));
+                }
+                &MaterialParam::Vec4(f1,f2,f3,f4) => {
+                    prog.set(&name, Vector4::new(f1,f2,f3,f4));
+                }
             }
         }
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -182,14 +182,14 @@ where
                 &MaterialParam::Float(f) => {
                     prog.set(&name, f);
                 }
-                &MaterialParam::Vec2(f1,f2) => {
-                    prog.set(&name, Vector2::new(f1,f2));
+                &MaterialParam::Vec2(v) => {
+                    prog.set(&name, v);
                 }
-                &MaterialParam::Vec3(f1,f2,f3) => {
-                    prog.set(&name, Vector3::new(f1,f2,f3));
+                &MaterialParam::Vec3(v) => {
+                    prog.set(&name, v);
                 }
-                &MaterialParam::Vec4(f1,f2,f3,f4) => {
-                    prog.set(&name, Vector4::new(f1,f2,f3,f4));
+                &MaterialParam::Vec4(v) => {
+                    prog.set(&name, v);
                 }
             }
         }

--- a/src/engine/render/material.rs
+++ b/src/engine/render/material.rs
@@ -4,13 +4,14 @@ use engine::render::{ShaderProgram, Texture};
 
 use std::rc::Rc;
 use std::collections::HashMap;
+use na::{Vector2, Vector3, Vector4};
 
 pub enum MaterialParam {
     Texture(Rc<Texture>),
     Float(f32),
-    Vec2(f32,f32),
-    Vec3(f32,f32,f32),
-    Vec4(f32,f32,f32,f32),
+    Vec2(Vector2<f32>),
+    Vec3(Vector3<f32>),
+    Vec4(Vector4<f32>),
 }
 
 pub struct Material {

--- a/src/engine/render/material.rs
+++ b/src/engine/render/material.rs
@@ -8,6 +8,9 @@ use std::collections::HashMap;
 pub enum MaterialParam {
     Texture(Rc<Texture>),
     Float(f32),
+    Vec2(f32,f32),
+    Vec3(f32,f32,f32),
+    Vec4(f32,f32,f32,f32),
 }
 
 pub struct Material {

--- a/src/engine/render/uniforms.rs
+++ b/src/engine/render/uniforms.rs
@@ -1,4 +1,4 @@
-use na::{Matrix4, Vector3};
+use na::{Matrix4, Vector2, Vector3, Vector4};
 use std::fmt::Debug;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
@@ -65,9 +65,33 @@ impl UniformAdapter for i32 {
     }
 }
 
+impl UniformAdapter for Vector2<f32> {
+    fn set(&self, gl: &WebGLRenderingContext, loc: &WebGLUniformLocation) {
+        gl.uniform_2f(&loc, (self.x, self.y));
+    }
+
+    fn to_hash(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        s.write(&self.as_slice().into_bytes());
+        s.finish()
+    }
+}
+
 impl UniformAdapter for Vector3<f32> {
     fn set(&self, gl: &WebGLRenderingContext, loc: &WebGLUniformLocation) {
         gl.uniform_3f(&loc, (self.x, self.y, self.z));
+    }
+
+    fn to_hash(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        s.write(&self.as_slice().into_bytes());
+        s.finish()
+    }
+}
+
+impl UniformAdapter for Vector4<f32> {
+    fn set(&self, gl: &WebGLRenderingContext, loc: &WebGLUniformLocation) {
+        gl.uniform_4f(&loc, (self.x, self.y, self.z, self.w));
     }
 
     fn to_hash(&self) -> u64 {

--- a/webgl/src/webgl.rs
+++ b/webgl/src/webgl.rs
@@ -604,6 +604,16 @@ impl GLContext {
         }
     }
 
+    pub fn uniform_2f(&self, location: &WebGLUniformLocation, value: (f32, f32)) {
+        js!{
+            var p = [@{value.0},@{value.1}];
+            var ctx = Module.gl.get(@{self.reference});
+            var loc = Module.gl.get(@{location.deref()});
+
+            ctx.uniform2f(loc,p[0],p[1])
+        }
+    }
+
     pub fn uniform_3f(&self, location: &WebGLUniformLocation, value: (f32, f32, f32)) {
         js!{
             var p = [@{value.0},@{value.1},@{value.2}];

--- a/webgl/src/webgl_native.rs
+++ b/webgl/src/webgl_native.rs
@@ -511,6 +511,12 @@ impl GLContext {
         }
     }
 
+    pub fn uniform_2f(&self, location: &WebGLUniformLocation, value: (f32, f32)) {
+        unsafe {
+            gl::Uniform2f(*location.deref() as _, value.0, value.1);
+        }
+    }
+
     pub fn uniform_3f(&self, location: &WebGLUniformLocation, value: (f32, f32, f32)) {
         unsafe {
             gl::Uniform3f(*location.deref() as _, value.0, value.1, value.2);


### PR DESCRIPTION
Shouldn't we use directly the tuples MaterialParam::VecN instead of going through a na::VectorN ? (to avoid creating temporary objects and be lighter on garbage collector for the web version)