### PR TITLE
don't hardcode clear values

### DIFF
--- a/examples/framebuffer.rs
+++ b/examples/framebuffer.rs
@@ -233,7 +233,7 @@ pub fn main() {
                 cam.rect = Some(((0, 0), (1024, 1024)));
 
                 // Render current scene by camera using given frame buffer
-                game.engine.render_pass(&cam);
+                game.engine.render_pass(&cam, ClearOption{color:Some((0.2,0.2,0.2,1.0)),clear_color:true, clear_depth:true, clear_stencil:false});
 
                 // Clean up stuffs in camera, as later we could render normally
                 cam.render_texture = None;
@@ -245,7 +245,7 @@ pub fn main() {
             }
 
             // Render
-            game.engine.render();
+            game.engine.render(ClearOption{color:Some((0.2,0.2,0.2,1.0)),clear_color:true, clear_depth:true, clear_stencil:false});
 
             // End
             game.engine.end();

--- a/examples/postprocessing.rs
+++ b/examples/postprocessing.rs
@@ -245,7 +245,7 @@ pub fn main() {
                     &format!("last event: {:?}", last_event),
                 );
                 // Render current scene by camera using given frame buffer
-                game.engine.render_pass(&cam);
+                game.engine.render_pass(&cam, ClearOption{color:Some((0.2,0.2,0.2,1.0)),clear_color:true,clear_depth:true, clear_stencil:false});
 
                 // Clean up stuffs in camera, as later we could render normally
                 cam.render_texture = None;
@@ -255,7 +255,7 @@ pub fn main() {
             game.list[5].borrow_mut().active = false;
             game.list[6].borrow_mut().active = true;
             // Render
-            game.engine.render();
+            game.engine.render(ClearOption{color:None,clear_color:true,clear_depth:true, clear_stencil:false});
 
             // End
             game.engine.end();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -305,7 +305,7 @@ pub fn main() {
             }
 
             // Render
-            game.engine.render();
+            game.engine.render(ClearOption{color:Some((0.2,0.2,0.2,1.0)),clear_color:true,clear_depth:true, clear_stencil:false});
 
             // End
             game.engine.end();

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -155,14 +155,32 @@ fn compute_model_m(object: &GameObject) -> Matrix4<f32> {
     modelm * Matrix4::new_nonuniform_scaling(&object.scale)
 }
 
+pub struct ClearOption {
+    pub color: Option<(f32,f32,f32,f32)>,
+    pub clear_color: bool,
+    pub clear_depth: bool,
+    pub clear_stencil: bool,
+}
+
 impl<A> Engine<A>
 where
     A: AssetSystem,
 {
-    pub fn clear(&self) {
-        self.gl.clear_color(0.2, 0.2, 0.2, 1.0);
-        self.gl.clear(BufferBit::Color);
-        self.gl.clear(BufferBit::Depth);
+    pub fn clear(&self, option: ClearOption) {
+        if let Some(col) = option.color {
+            self.gl.clear_color(col.0, col.1, col.2, col.3);
+        } else {
+            self.gl.clear_color(0.0, 0.0, 0.0, 1.0);
+        }
+        if option.clear_color {
+            self.gl.clear(BufferBit::Color);
+        }
+        if option.clear_depth {
+            self.gl.clear(BufferBit::Depth);
+        }
+        if option.clear_stencil {
+            self.gl.clear(BufferBit::Stencil);
+        }
     }
 
     fn setup_material(
@@ -350,7 +368,7 @@ where
                 .collect();
     }
 
-    pub fn render_pass(&self, camera: &Camera) {
+    pub fn render_pass(&self, camera: &Camera, clear_option: ClearOption) {
         let objects = &self.objects;
 
         let mut ctx: EngineContext = Default::default();
@@ -366,7 +384,7 @@ where
                 .viewport(0, 0, self.screen_size.0, self.screen_size.1);
         }
 
-        self.clear();
+        self.clear(clear_option);
 
         self.prepare_ctx(&mut ctx);
 
@@ -396,11 +414,11 @@ where
         }
     }
 
-    pub fn render(&mut self) {
+    pub fn render(&mut self, clear_option: ClearOption) {
         imgui::pre_render(self);
 
         if let Some(ref camera) = self.main_camera.as_ref() {
-            self.render_pass(&camera.borrow());
+            self.render_pass(&camera.borrow(), clear_option);
         }
 
         // drop all gameobjects if there are no other references

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,6 @@ pub use self::imgui::Metric;
 pub use self::render::*;
 pub use self::asset::*;
 pub use self::core::{Component, ComponentBased, GameObject};
-pub use self::engine::IEngine;
+pub use self::engine::{IEngine,ClearOption};
 
 pub type Engine<FS, F> = engine::Engine<AssetDatabase<FS, F>>;


### PR DESCRIPTION
Ok this is a proposal to avoid hardcoding the buffer clearing in the engine (currently with color 0.2, 0.2, 0.2, 1.0).
It's quite verbose as is, I'm not sure what you want to be enforced by the engine. Typically I've never used stencil.
but being able to choose the clearing color and whether you clear color and/or depth buffers seems important.