### PR TITLE
don't hardcode camera aspect ratio

### DIFF
--- a/examples/postprocessing.rs
+++ b/examples/postprocessing.rs
@@ -241,7 +241,15 @@ pub fn main() {
                     &format!("last event: {:?}", last_event),
                 );
                 // Render current scene by camera using given frame buffer
-                game.engine.render_pass(&cam, ClearOption{color:Some((0.2,0.2,0.2,1.0)),clear_color:true,clear_depth:true, clear_stencil:false});
+                game.engine.render_pass(
+                    &cam,
+                    ClearOption {
+                        color: Some((0.2, 0.2, 0.2, 1.0)),
+                        clear_color: true,
+                        clear_depth: true,
+                        clear_stencil: false,
+                    },
+                );
 
                 // Clean up stuffs in camera, as later we could render normally
                 cam.render_texture = None;
@@ -251,7 +259,12 @@ pub fn main() {
             game.list[5].borrow_mut().active = false;
             game.list[6].borrow_mut().active = true;
             // Render
-            game.engine.render(ClearOption{color:None,clear_color:true,clear_depth:true, clear_stencil:false});
+            game.engine.render(ClearOption {
+                color: None,
+                clear_color: true,
+                clear_depth: true,
+                clear_stencil: false,
+            });
 
             // End
             game.engine.end();

--- a/examples/postprocessing.rs
+++ b/examples/postprocessing.rs
@@ -207,6 +207,17 @@ pub fn main() {
                 }
             }
 
+            // Update Camera
+            {
+                let mut cam = game.engine.main_camera.as_ref().unwrap().borrow_mut();
+
+                cam.lookat(
+                    &Point3::from_coordinates(eye),
+                    &Point3::new(0.0, 0.0, 0.0),
+                    &Vector3::new(0.0, 1.0, 0.0),
+                );
+            }
+
             // Setup fb for camera
             {
                 let mut cam = game.engine.main_camera.as_ref().unwrap().borrow_mut();
@@ -214,12 +225,6 @@ pub fn main() {
 
                 // Setup proper viewport to render to the whole texture
                 cam.rect = Some(((0, 0), (1024, 1024)));
-                cam.lookat(
-                    &Point3::from_coordinates(eye),
-                    &Point3::new(0.0, 0.0, 0.0),
-                    &Vector3::new(0.0, 1.0, 0.0),
-                );
-
                 // show only cube
                 game.list[5].borrow_mut().active = true;
                 game.list[6].borrow_mut().active = false;

--- a/examples/postprocessing.rs
+++ b/examples/postprocessing.rs
@@ -195,16 +195,6 @@ pub fn main() {
                 }
             }
 
-            // Update Camera
-            {
-                let mut cam = game.engine.main_camera.as_ref().unwrap().borrow_mut();
-                cam.lookat(
-                    &Point3::from_coordinates(eye),
-                    &Point3::new(0.0, 0.0, 0.0),
-                    &Vector3::new(0.0, 1.0, 0.0),
-                );
-            }
-
             // Update Light
             for light_com_weak in game.point_light_coms.iter() {
                 if let Some(light_com) = light_com_weak.upgrade() {
@@ -224,6 +214,12 @@ pub fn main() {
 
                 // Setup proper viewport to render to the whole texture
                 cam.rect = Some(((0, 0), (1024, 1024)));
+                cam.lookat(
+                    &Point3::from_coordinates(eye),
+                    &Point3::new(0.0, 0.0, 0.0),
+                    &Vector3::new(0.0, 1.0, 0.0),
+                );
+
                 // show only cube
                 game.list[5].borrow_mut().active = true;
                 game.list[6].borrow_mut().active = false;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -156,7 +156,7 @@ fn compute_model_m(object: &GameObject) -> Matrix4<f32> {
 }
 
 pub struct ClearOption {
-    pub color: Option<(f32,f32,f32,f32)>,
+    pub color: Option<(f32, f32, f32, f32)>,
     pub clear_color: bool,
     pub clear_depth: bool,
     pub clear_stencil: bool,
@@ -238,7 +238,7 @@ where
         let prog = ctx.prog.upgrade().unwrap();
         // setup_camera
         prog.set("uMVMatrix", camera.v * modelm);
-        prog.set("uPMatrix", camera.p);
+        prog.set("uPMatrix", camera.perspective(self.screen_size));
         prog.set("uNMatrix", modelm.try_inverse().unwrap().transpose());
         prog.set("uMMatrix", modelm);
         prog.set("uViewPos", camera.eye());

--- a/src/engine/render/camera.rs
+++ b/src/engine/render/camera.rs
@@ -17,7 +17,11 @@ pub struct Camera {
 impl Camera {
     pub fn lookat(&mut self, eye: &Point3<f32>, target: &Point3<f32>, up: &Vector3<f32>) {
         self.v = Matrix4::look_at_rh(eye, target, up);
-        self.p = Matrix4::new_perspective(800.0 / 600.0, 3.1415 / 4.0, 1.0, 1000.0);
+        let mut aspect: f32 = 800.0/600.0;
+        if let Some(((_,_),(w,h))) = self.rect {
+            aspect = w as f32 / h as f32;
+        }
+        self.p = Matrix4::new_perspective(aspect, 3.1415 / 4.0, 1.0, 1000.0);
         self.eye = *eye;
     }
 

--- a/src/engine/render/camera.rs
+++ b/src/engine/render/camera.rs
@@ -4,7 +4,6 @@ use engine::render::RenderTexture;
 
 pub struct Camera {
     pub v: Matrix4<f32>,
-    pub p: Matrix4<f32>,
 
     /// Optional viewport of this camera,  (pos, size) in pixels
     /// from 0 (left/top) to screen width/height (right/bottom)
@@ -17,18 +16,22 @@ pub struct Camera {
 impl Camera {
     pub fn lookat(&mut self, eye: &Point3<f32>, target: &Point3<f32>, up: &Vector3<f32>) {
         self.v = Matrix4::look_at_rh(eye, target, up);
-        let mut aspect: f32 = 800.0/600.0;
-        if let Some(((_,_),(w,h))) = self.rect {
+        self.eye = *eye;
+    }
+
+    pub fn perspective(&self, screen_size: (u32, u32)) -> Matrix4<f32> {
+        let mut aspect: f32 = (screen_size.0 as f32) / (screen_size.1 as f32);
+
+        if let Some(((_, _), (w, h))) = self.rect {
             aspect = w as f32 / h as f32;
         }
-        self.p = Matrix4::new_perspective(aspect, 3.1415 / 4.0, 1.0, 1000.0);
-        self.eye = *eye;
+
+        Matrix4::new_perspective(aspect, 3.1415 / 4.0, 1.0, 1000.0)
     }
 
     pub fn new() -> Camera {
         Camera {
             v: Matrix4::identity(),
-            p: Matrix4::identity(),
             eye: Point3::new(0.0, 0.0, 0.0),
             rect: None,
             render_texture: None,


### PR DESCRIPTION
camera uses hardcoded 800/600 aspect ratio. When viewport is defined, compute the actual aspect ratio. Note that when viewport is not defined, it should still use screen size from engine instead of 800/600. Not sure how to get them here but this PR at least fixes the case when there's a viewport defined.

The problem is that you have to call look_at AFTER defining the viewport. This dependency is not explicit which is not great...