### PR TITLE
fix #11

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -302,6 +302,7 @@ where
                 Ok(_) => {
                     prog.commit(gl);
                     cmd.surface.buffer.render(gl);
+                    cmd.surface.buffer.unbind(gl);
                 }
                 Err(ref err) => match *err {
                     AssetError::NotReady => (),

--- a/src/engine/render/mesh_buffer.rs
+++ b/src/engine/render/mesh_buffer.rs
@@ -126,6 +126,7 @@ impl MeshBuffer {
         let state = state_option.as_ref().unwrap();
 
         /*======= Associating shaders to buffer objects =======*/
+        gl.bind_vertex_array(&state.vao);
 
         // Bind vertex buffer object
         gl.bind_buffer(BufferKind::Array, &state.vb);

--- a/src/engine/render/mesh_buffer.rs
+++ b/src/engine/render/mesh_buffer.rs
@@ -24,6 +24,7 @@ impl<T> IntoBytes for Vec<T> {
 }
 
 struct MeshGLState {
+    pub vao: WebGLVertexArray,
     pub vb: WebGLBuffer,
     pub uvb: Option<WebGLBuffer>,
     pub nb: Option<WebGLBuffer>,
@@ -175,6 +176,9 @@ fn mesh_bind_buffer(
     indices: &Vec<u16>,
     gl: &WebGLRenderingContext,
 ) -> MeshGLState {
+    let vao = gl.create_vertex_array();
+    gl.bind_vertex_array(&vao);
+
     // Create an empty buffer object to store vertex buffer
     let vertex_buffer = gl.create_buffer();
     {
@@ -245,6 +249,7 @@ fn mesh_bind_buffer(
     }
 
     MeshGLState {
+        vao,
         vb: vertex_buffer,
         uvb: uv_buffer,
         nb: normal_buffer,

--- a/src/engine/render/mesh_buffer.rs
+++ b/src/engine/render/mesh_buffer.rs
@@ -168,7 +168,7 @@ impl MeshBuffer {
         gl.draw_elements(Primitives::Triangles, data.indices.len(), DataType::U16, 0);
     }
 
-    pub fn unbind(&self) {
+    pub fn unbind(&self, gl: &WebGLRenderingContext) {
         gl.unbind_vertex_array();
     }
 }

--- a/src/engine/render/mesh_buffer.rs
+++ b/src/engine/render/mesh_buffer.rs
@@ -167,6 +167,10 @@ impl MeshBuffer {
 
         gl.draw_elements(Primitives::Triangles, data.indices.len(), DataType::U16, 0);
     }
+
+    pub fn unbind(&self) {
+        gl.unbind_vertex_array();
+    }
 }
 
 fn mesh_bind_buffer(
@@ -176,6 +180,7 @@ fn mesh_bind_buffer(
     indices: &Vec<u16>,
     gl: &WebGLRenderingContext,
 ) -> MeshGLState {
+    // some opengl 3.x core profile require a VAO. See issue #11
     let vao = gl.create_vertex_array();
     gl.bind_vertex_array(&vao);
 

--- a/src/engine/render/mesh_buffer.rs
+++ b/src/engine/render/mesh_buffer.rs
@@ -169,7 +169,9 @@ impl MeshBuffer {
     }
 
     pub fn unbind(&self, gl: &WebGLRenderingContext) {
-        gl.unbind_vertex_array();
+        let state_option = self.gl_state.borrow();
+        let state = state_option.as_ref().unwrap();
+        gl.unbind_vertex_array(&state.vao);
     }
 }
 

--- a/webgl/src/webgl.rs
+++ b/webgl/src/webgl.rs
@@ -670,7 +670,8 @@ impl GLContext {
         js! {
             var ctx = Module.gl.get(@{self.reference});
             if (ctx.unbindVertexArray) {
-                ctx.unbindVertexArray(0);
+                var vao = Module.gl.get(@{vao.deref()});
+                ctx.unbindVertexArray(vao);
             }
         }
     }

--- a/webgl/src/webgl.rs
+++ b/webgl/src/webgl.rs
@@ -665,7 +665,7 @@ impl GLContext {
         }
     }
 
-    pub fn unbind_vertex_array(&self) {
+    pub fn unbind_vertex_array(&self, vao: &WebGLVertexArray) {
         self.log("unbind_vertex_array");
         js! {
             var ctx = Module.gl.get(@{self.reference});

--- a/webgl/src/webgl.rs
+++ b/webgl/src/webgl.rs
@@ -10,7 +10,7 @@ pub type WebGLContext<'a> = &'a CanvasElement;
 impl WebGLRenderingContext {
     pub fn new(canvas: WebGLContext) -> WebGLRenderingContext {
         WebGLRenderingContext {
-            common: GLContext::new(&canvas.clone().into(), "webgl"),
+            common: GLContext::new(&canvas.clone().into()),
         }
     }
 }
@@ -75,9 +75,12 @@ impl GLContext {
         js!{ console.log(@{msg.into()})};
     }
 
-    pub fn new<'a>(canvas: &Element, context: &'a str) -> GLContext {
+    pub fn new<'a>(canvas: &Element) -> GLContext {
         let gl = js!{
-            var gl = (@{canvas}).getContext(@{context});
+            var gl = (@{canvas}).getContext("webgl2");
+            if (!gl) {
+                gl = (@{canvas}).getContext("webgl");
+            }
 
             // Create gl related objects
             if( !Module.gl) {
@@ -642,9 +645,12 @@ impl GLContext {
         self.log("create_vertex_array");
         let val = js! {
             var ctx = Module.gl.get(@{self.reference});
-            return Module.gl.add(ctx.createVertexArray());
+            if (ctx.createVertexArray) {
+                return Module.gl.add(ctx.createVertexArray());
+            } else {
+                return 0;
+            }
         };
-
         WebGLVertexArray(val.try_into().unwrap())
     }
 
@@ -652,8 +658,10 @@ impl GLContext {
         self.log("bind_vertex_array");
         js! {
             var ctx = Module.gl.get(@{self.reference});
-            var vao = Module.gl.get(@{vao.deref()});
-            ctx.bindVertexArray(vao)
+            if (ctx.bindVertexArray) {
+                var vao = Module.gl.get(@{vao.deref()});
+                ctx.bindVertexArray(vao);
+            }
         }
     }
 
@@ -661,7 +669,9 @@ impl GLContext {
         self.log("unbind_vertex_array");
         js! {
             var ctx = Module.gl.get(@{self.reference});
-            ctx.bindVertexArray(0)
+            if (ctx.unbindVertexArray) {
+                ctx.unbindVertexArray(0);
+            }
         }
     }
 

--- a/webgl/src/webgl_native.rs
+++ b/webgl/src/webgl_native.rs
@@ -570,10 +570,11 @@ impl GLContext {
         check_gl_error("bind_vertex_array");
     }
 
-    pub fn unbind_vertex_array(&self) {
+    pub fn unbind_vertex_array(&self, vao: &WebGLVertexArray) {
         unsafe {
-            gl::BindVertexArray(0);
+            gl::BindVertexArray(vao.0);
         }
+        check_gl_error("unbind_vertex_array");
     }
 
     pub fn create_framebuffer(&self) -> WebGLFrameBuffer {

--- a/webgl/src/webgl_native.rs
+++ b/webgl/src/webgl_native.rs
@@ -559,6 +559,7 @@ impl GLContext {
         unsafe {
             gl::GenVertexArrays(1, &mut vao.0);
         }
+        check_gl_error("create_vertex_array");
         vao
     }
 
@@ -566,6 +567,7 @@ impl GLContext {
         unsafe {
             gl::BindVertexArray(vao.0);
         }
+        check_gl_error("bind_vertex_array");
     }
 
     pub fn unbind_vertex_array(&self) {


### PR DESCRIPTION
This uses a vertex array object when it's available to keep opengl 3.x core profile happy.

It's still not perfect :
* with a VAO, we could bind all the vertex data only once, then during rendering, do only bind_vertex_array, then draw_elements.
* I can't unbind the VAO right now because MeshBuffer::render() is called several times. We need a MeshBuffer::unbind to be called after all the rendering work

I don't expect this to be merged in the master right now as it's quite hacky but at least it makes the engine work on some exotic opengl configurations. On another hand, VAO is something we should integrate in the engine at some point so this might be a first step.